### PR TITLE
Fix mnemonic types conflict

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -72,9 +72,7 @@ class _MyAppState extends State<MyApp> {
         ldk.SocketAddress.hostname(addr: "0.0.0.0", port: 3003));
     ldk.Builder aliceBuilder = ldk.Builder.fromConfig(config: aliceConfig);
     aliceNode = await aliceBuilder
-        .setEntropyBip39Mnemonic(
-            mnemonic: ldk.Mnemonic(
-                "cart super leaf clinic pistol plug replace close super tooth wealth usage"))
+        .setEntropyBip39Mnemonic(mnemonic: await ldk.Mnemonic.generate())
         .setEsploraServer(esploraUrl)
         .build();
     await startNode(aliceNode);

--- a/lib/src/root.dart
+++ b/lib/src/root.dart
@@ -7,9 +7,9 @@ import 'package:path_provider/path_provider.dart';
 class Mnemonic extends bridge.Mnemonic {
   Mnemonic(String seedPhrase)
       : super(bridge: loaderApi, seedPhrase: seedPhrase);
-  static Future<bridge.Mnemonic> generate() async {
+  static Future<Mnemonic> generate() async {
     final res = await bridge.Mnemonic.generate(bridge: loaderApi);
-    return res;
+    return Mnemonic(res.seedPhrase);
   }
 }
 


### PR DESCRIPTION
The return type of the generate function of ldk-node-flutter's `Mnemonic` class was of the type `bridge.Mnemonic`. Even though the `Mnemonic` class extends the `bridge.Mnemonic` type and so a `Mnemonic` instance can be used wherever a `bridge.Mnemonic` is needed, the reverse doesn't work: a generated mnemonic could not be assigned to the `Mnemonic` class itself.

So the same `Mnemonic` type could not be used to assign a generated mnemonic or a mnemonic from a seed phrase. The following code snippet gave an error:

```
Mnemonic mnemonic; // An instance of ldk_node's Mnemonic class

String? storedMnemonic =
    await _mnemonicRepository.getMnemonic(_walletType.label);
if (storedMnemonic == null || storedMnemonic.isEmpty) {
  mnemonic = await Mnemonic.generate(); // Returns a bridge.Mnemonic type and so gives an error trying to assign it to mnemonic
 // ... 
} else {
  mnemonic = Mnemonic(storedMnemonic);
}
 ```

The error that is caused by the `generate` function is the following:

> A value of type 'Mnemonic (where Mnemonic is defined in /Users/*/.pub-cache/git/ldk-node-flutter-dad6e88c80acf940d068c14dbd7a8d170f05a690/lib/src/generated/bridge_definitions.dart)' can't be assigned to a variable of type 'Mnemonic (where Mnemonic is defined in /Users/*/.pub-cache/git/ldk-node-flutter-dad6e88c80acf940d068c14dbd7a8d170f05a690/lib/src/root.dart)'.
> Try changing the type of the variable, or casting the right-hand type to 'Mnemonic (where Mnemonic is defined in /Users/*/.pub-cache/git/ldk-node-flutter-dad6e88c80acf940d068c14dbd7a8d170f05a690/lib/src/root.dart)'.dart[invalid_assignment](https://dart.dev/diagnostics/invalid_assignment)
> bridge_definitions.dart(821, 7): Mnemonic is defined in /Users/*/.pub-cache/git/ldk-node-flutter-dad6e88c80acf940d068c14dbd7a8d170f05a690/lib/src/generated/bridge_definitions.dart
> root.dart(7, 7): Mnemonic is defined in /Users/*/.pub-cache/git/ldk-node-flutter-dad6e88c80acf940d068c14dbd7a8d170f05a690/lib/src/root.dart

 
 This Pull Request fixes this issue by letting the `generate` function return an instance of the `Mnemonic` type, like this the user only has to use the `Mnemonic` type and not the `bridge.Mnemonic`.
 
 In the example app I also changed one hardcoded mnemonic for a generated mnemonic as to demonstrate the `generate` function.